### PR TITLE
Installing grunt-cli alongside

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "test": "grunt test"
   },
   "preferGlobal": true,
+  "peerDependencies": {
+    "grunt-cli": "~0.1.9"
+  },
   "dependencies": {
     "nopt": "~1.0.10"
   },


### PR DESCRIPTION
Will make `npm install -g grunt-cli happyplan-cli` to `npm install -g happyplan-cli` only

![](http://i.imgur.com/GTV1ekG.gif)
